### PR TITLE
Change reader type from io.Reader to *io.PipeReader in read function

### DIFF
--- a/201-io/pipe.go
+++ b/201-io/pipe.go
@@ -16,7 +16,7 @@ func main() {
 	<-done
 }
 
-func read(reader io.Reader, done chan struct{}) {
+func read(reader *io.PipeReader, done chan struct{}) {
 	buff := make([]byte, 1024)
 	for {
 		readed, err := reader.Read(buff)


### PR DESCRIPTION
- Modified the function signature to accept *io.PipeReader for more specific use cases.